### PR TITLE
fix: refactor products route to use allTickers endpoint

### DIFF
--- a/backend/models/products.model.js
+++ b/backend/models/products.model.js
@@ -8,13 +8,15 @@ const getSharedProducts = async () => {
     const [BFX,BNB,BTX] = allProducts;
     const spread = [...BFX,...BNB,...BTX];
     const products = spread.reduce((acc,product) => {
-      acc[product.id] = acc[product.id]+1 || 1;
+      // acc[product.id] = acc[product.id]+1 || 1;
+      acc[product.product] = acc[product.product]+1 || 1;
       return acc;
     },{});
     let sharedProducts = [];
     for (let product in products) {
       if (products[product] === 3) sharedProducts.push(product);
     }
+    sharedProducts.sort();
     return sharedProducts;
   }
   catch (error) {

--- a/backend/services/moneeda-api.service.js
+++ b/backend/services/moneeda-api.service.js
@@ -5,8 +5,9 @@ const { MONEEDA_BASE_URL, MONEEDA_API_TOKEN } = process.env;
 
 const productURL = exchange => `${MONEEDA_BASE_URL}/api/exchanges/${exchange}/products`;
 const tickerURL = exchange => `${MONEEDA_BASE_URL}/api/exchanges/${exchange}/ticker`;
+const allTickersURL = exchange => `${MONEEDA_BASE_URL}/api/exchanges/${exchange}/alltickers`;
 
-exports.getProducts = exchange => axios.get(productURL(exchange),{
+exports.getProducts = exchange => axios.get(allTickersURL(exchange),{
   headers: {'Authorization': `Bearer ${MONEEDA_API_TOKEN}`},
 }).then(response => response.data);
 
@@ -18,10 +19,14 @@ exports.getPrice = async (exchange,product) => {
     });
     return {
       exchange,
-      price: response.data.price
+      price: response.data.price.toFixed(8)
     };
   }
   catch (error) {
+    return {
+      exchange,
+      price: -1 //Returns a value of -1 when the product was listed in the exchange product list but somehow returns a message of 'invalid market' when trying to get the price
+    };
     console.error(error); // eslint-disable-line no-console
   }
 };


### PR DESCRIPTION
Discovered that the /products endpoint from the Moneeda API was returning products that were no longer available from Bittrex. Refactored the products route to use the /alltickers endpoint from the Moneeda API instead, which was found to be more up to date, thus providing a more accurate shared products result.